### PR TITLE
use .get() to fetch key in get_general

### DIFF
--- a/ovh_cli/secret.py
+++ b/ovh_cli/secret.py
@@ -18,20 +18,20 @@ def get_config(key):
 def get_general(key="general"):
     config = get_config(key)
     return {
-        "project_name": config[key]['project_name'],
-        "base_distrib": config[key]['base_distrib'],
-        "region": config[key]['region'],
-        "ssh_key_id": config[key]['ssh_key_id'],
-        "inventary_file": config[key]['inventary_file'],
-        "private_network_id": config[key]['private_network_id'],
-        "public_network_id": config[key]['public_network_id']
+        "project_name": config[key].get('project_name'),
+        "base_distrib": config[key].get('base_distrib'),
+        "region": config[key].get('region'),
+        "ssh_key_id": config[key].get('ssh_key_id'),
+        "inventary_file": config[key].get('inventary_file'),
+        "private_network_id": config[key].get('private_network_id'),
+        "public_network_id": config[key].get('public_network_id')
     }
 
 
 def get_ovh_connection_setting(key="get-info"):
     config = get_config(key)
     return {
-        "application_key": config[key]['application_key'],
-        "application_secret": config[key]['application_secret'],
-        "consumer_key": config[key]['consumer_key']
+        "application_key": config[key].get('application_key'),
+        "application_secret": config[key].get('application_secret'),
+        "consumer_key": config[key].get('consumer_key')
     }


### PR DESCRIPTION
Salut,

Alors le fichier de config `~/.ovh-cli/secret`

Y a cette méthode, qui veut des clés que je n'ai pas encore.
Pour l'initialisation du projet, il faudrait que cette méthode ne plante pas quand il n'y a pas les valeurs.

Tu vois pour remplir `ssh_key_id` je voulais faire un  `ovh-get-info ssh_key`
Comme les `private_network_id`, je n'en ai pas.

```
ovh_cli/secret.py
def get_general(key="general"):
    config = get_config(key)
    return {
        "project_name": config[key]['project_name'],
        "base_distrib": config[key]['base_distrib'],
        "region": config[key]['region'],
        "ssh_key_id": config[key]['ssh_key_id'],
        "inventary_file": config[key]['inventary_file'],                                                                             
        "private_network_id": config[key]['private_network_id'],
        "public_network_id": config[key]['public_network_id']
    }
```
Idem pour `ovh-manage-vm` qui s'attend à trouver une section `[vm]`

Aussi peut-être les noms de sections devraient  être identiques au noms des programmes

```
[get-info]
[manage-credential]
[manage-dns]
[manage-network]
[manage-telephony]
[manage-vm]
```

Pour quoi pas séparer le secret de la config ?

```
~/.ovh-cli/secret    <== ne contient que les secrets
~/.ovh-cli/config    <== contient les préférences
```

On pourrait avoir un argument `init` ou `init_config` qui dump des gabarits de fichier, qu'en penses-tu ?